### PR TITLE
Add `num_retries` to api calls

### DIFF
--- a/src/calendar.py
+++ b/src/calendar.py
@@ -9,6 +9,7 @@ SCOPES = [
 
 COPIED_EVENT_LEADING_TEXT = '[CLIENT MEETING]'
 
+NUM_RETRIES = 10
 
 class Calendar:
     def __init__(self, calendarId, googleService):
@@ -23,7 +24,7 @@ class Calendar:
     def getEvents(self, period: DatePeriod):
         events_result = self.googleService.events().list(calendarId=self.calendarId, timeMin=period.start,
                                                          timeMax=period.end, singleEvents=True,
-                                                         orderBy='startTime').execute()
+                                                         orderBy='startTime').execute(num_retries=NUM_RETRIES)
         events = events_result.get('items', [])
         return events
 
@@ -34,7 +35,7 @@ class Calendar:
             self.deleteEvent(event.get("id"))
 
     def deleteEvent(self, eventId):
-        self.googleService.events().delete(calendarId=self.calendarId, eventId=eventId).execute()
+        self.googleService.events().delete(calendarId=self.calendarId, eventId=eventId).execute(num_retries=NUM_RETRIES)
 
     def createEventFrom(self, sourceEvent, copySensibleData):
         eventBody = {
@@ -50,7 +51,7 @@ class Calendar:
             'reminders': sourceEvent.get('reminders'),
         }
 
-        createdEvent = self.googleService.events().insert(calendarId=self.calendarId, body=eventBody).execute()
+        createdEvent = self.googleService.events().insert(calendarId=self.calendarId, body=eventBody).execute(num_retries=NUM_RETRIES)
 
         return createdEvent
 


### PR DESCRIPTION
With larger periods, the script would regularly hit the quota limit of
the free tier and abort with an HttpError exception and status code 403.

It seems this can be mitigated by setting a `num_retries`, which
includes an exponential backoff mechanism.

From the [google-api-python-client docs](https://github.com/googleapis/google-api-python-client/blob/cbb1f88b82b21f5cb9dcace33ffea3f95a189015/googleapiclient/http.py#L882):

> num_retries: Integer, number of times to retry with randomized
> exponential backoff. If all retries fail, the raised HttpError
> represents the last request. If zero (default), we attempt the
> request only once.