### PR TITLE
Add option to skip matching meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ python3 gcalsync.py account1 "calendar-id-21" account2 "calendar-id-33" 1d
 
 `NOTE:` The command can safely be executed several times. All the already synchronised events will be removed from the target calendar and recreated. 
 
-`NOTE:` By default, the name, description and location of the events are not copied to prevent exposing sensible data, but copying of sensible data can be enabled by adding the parameter `copySensibleData` at the end. Eg.
+`NOTE:` By default, the name, description and location of the events are not copied to prevent exposing sensible data, but copying of sensible data can be enabled by adding the parameter `--copySensibleData` at the end. Eg.
 
 ```shell script
-python3 gcalsync.py account1 "calendar-id-21" account2 "calendar-id-33" 1d copySensibleData
+python3 gcalsync.py account1 "calendar-id-21" account2 "calendar-id-33" 1d --copySensibleData
 ```
 
 ### What if my organisation does not allow Google API?

--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ python3 gcalsync.py account1 "calendar-id-21" account2 "calendar-id-33" 1d
 python3 gcalsync.py account1 "calendar-id-21" account2 "calendar-id-33" 1d --copySensibleData
 ```
 
+`NOTE:` Use the `--colorId` argument to pick a color number (try values 1, 2, 3.. and so on) in order to visually distinguish the synced events:
+```shell script
+python3 gcalsync.py account1 "calendar-id-21" account2 "calendar-id-33" 1d --colorId 5
+```
+See the
+[colors](https://developers.google.com/calendar/api/v3/reference/colors/get) resource for more details and possible values.
+
 ### What if my organisation does not allow Google API?
 
 In that case, it is still possible to use `gcalsync`. Imagine that source account `account1` does not allow Google API. In that case, we won't be able to create the credentials file to copy events from `account1`.

--- a/gcalsync.py
+++ b/gcalsync.py
@@ -1,9 +1,10 @@
 from src.date_period import DatePeriod
 from src.calendar_service import CalendarService
 import sys
+import argparse
 
 
-def main(sourceAccountName, sourceCalendarId, targetAccountName, targetCalendarId, datePeriod, copySensibleData):
+def main(sourceAccountName, sourceCalendarId, targetAccountName, targetCalendarId, datePeriod, copySensibleData, colorId):
     print(f'Copying from {sourceAccountName}:{sourceCalendarId} to {targetAccountName}:{targetCalendarId}'
           f' from {datePeriod.start} to {datePeriod.end}')
     if copySensibleData:
@@ -12,18 +13,22 @@ def main(sourceAccountName, sourceCalendarId, targetAccountName, targetCalendarI
     sourceCalendar = CalendarService(sourceAccountName).getCalendar(sourceCalendarId)
     targetCalendar = CalendarService(targetAccountName).getCalendar(targetCalendarId)
 
-    targetCalendar.copyAllEventsFrom(sourceCalendar, DatePeriod.weeks(1), copySensibleData)
+    targetCalendar.copyAllEventsFrom(sourceCalendar, DatePeriod.weeks(1), copySensibleData, colorId)
 
     print('Events copied successfully')
 
 
 if __name__ == '__main__':
-    if len(sys.argv) < 6:
-        print(
-            f"Usage python3 gcalsync sourceAccountName sourceCalendarId targetAccountName targetCalendarId [copySensibleData]")
+    parser = argparse.ArgumentParser(description='This command copies event from a source calendar to a target one.')
+    parser.add_argument('sourceAccountName', type=str, help='Name of the source account (credentials file prefix)')
+    parser.add_argument('sourceCalendarId', type=str, help='Name of the source calendar (use `gcallist` to find)')
+    parser.add_argument('targetAccountName', type=str, help='Name of the target account (credentials file prefix)')
+    parser.add_argument('targetCalendarId', type=str, help='Name of the source calendar (use `gcallist` to find)')
+    parser.add_argument('period', type=str, help='Period of events to copy, e.g. 2d or 1w')
+    parser.add_argument('--copySensibleData', action='store_true', help='If set, copies event names and details')
+    parser.add_argument('--colorId', type=str, default=None, help='If set, uses custom color (see `colors` resource)')
 
-    copySensibleData = len(sys.argv) > 6 and sys.argv[6] == 'copySensibleData'
-
-    main(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], DatePeriod.parse(sys.argv[5]), copySensibleData)
+    args = parser.parse_args()
+    main(args.sourceAccountName, args.sourceCalendarId, args.targetAccountName, args.targetCalendarId, DatePeriod.parse(args.period), args.copySensibleData, args.colorId)
     ## Pass as first an single argument the ID of your client calendar visible from your TW account
     ## use  target.printCalendars() to see all your calendars and find out this id.

--- a/gcalsync.py
+++ b/gcalsync.py
@@ -4,7 +4,7 @@ import sys
 import argparse
 
 
-def main(sourceAccountName, sourceCalendarId, targetAccountName, targetCalendarId, datePeriod, copySensibleData, colorId):
+def main(sourceAccountName, sourceCalendarId, targetAccountName, targetCalendarId, datePeriod, copySensibleData, colorId, skipMatching):
     print(f'Copying from {sourceAccountName}:{sourceCalendarId} to {targetAccountName}:{targetCalendarId}'
           f' from {datePeriod.start} to {datePeriod.end}')
     if copySensibleData:
@@ -13,7 +13,7 @@ def main(sourceAccountName, sourceCalendarId, targetAccountName, targetCalendarI
     sourceCalendar = CalendarService(sourceAccountName).getCalendar(sourceCalendarId)
     targetCalendar = CalendarService(targetAccountName).getCalendar(targetCalendarId)
 
-    targetCalendar.copyAllEventsFrom(sourceCalendar, DatePeriod.weeks(1), copySensibleData, colorId)
+    targetCalendar.copyAllEventsFrom(sourceCalendar, DatePeriod.weeks(1), copySensibleData, colorId, skipMatching)
 
     print('Events copied successfully')
 
@@ -27,8 +27,9 @@ if __name__ == '__main__':
     parser.add_argument('period', type=str, help='Period of events to copy, e.g. 2d or 1w')
     parser.add_argument('--copySensibleData', action='store_true', help='If set, copies event names and details')
     parser.add_argument('--colorId', type=str, default=None, help='If set, uses custom color (see `colors` resource)')
+    parser.add_argument('--skipMatching', action='store_true', help='If set, does not copy events if there already exists an event in the target calendar with the same start and end time')
 
     args = parser.parse_args()
-    main(args.sourceAccountName, args.sourceCalendarId, args.targetAccountName, args.targetCalendarId, DatePeriod.parse(args.period), args.copySensibleData, args.colorId)
+    main(args.sourceAccountName, args.sourceCalendarId, args.targetAccountName, args.targetCalendarId, DatePeriod.parse(args.period), args.copySensibleData, args.colorId, args.skipMatching)
     ## Pass as first an single argument the ID of your client calendar visible from your TW account
     ## use  target.printCalendars() to see all your calendars and find out this id.

--- a/gcalsync.py
+++ b/gcalsync.py
@@ -13,7 +13,7 @@ def main(sourceAccountName, sourceCalendarId, targetAccountName, targetCalendarI
     sourceCalendar = CalendarService(sourceAccountName).getCalendar(sourceCalendarId)
     targetCalendar = CalendarService(targetAccountName).getCalendar(targetCalendarId)
 
-    targetCalendar.copyAllEventsFrom(sourceCalendar, DatePeriod.weeks(1), copySensibleData, colorId, skipMatching)
+    targetCalendar.copyAllEventsFrom(sourceCalendar, datePeriod, copySensibleData, colorId, skipMatching)
 
     print('Events copied successfully')
 

--- a/src/calendar.py
+++ b/src/calendar.py
@@ -15,10 +15,10 @@ class Calendar:
         self.calendarId = calendarId
         self.googleService = googleService
 
-    def copyAllEventsFrom(self, otherCalendar, period: DatePeriod, copySensibleData):
+    def copyAllEventsFrom(self, otherCalendar, period: DatePeriod, copySensibleData, colorId):
         self.removeCopiedEvents(period)
         for event in otherCalendar.getEvents(period):
-            self.createEventFrom(event, copySensibleData)
+            self.createEventFrom(event, copySensibleData, colorId)
 
     def getEvents(self, period: DatePeriod):
         events_result = self.googleService.events().list(calendarId=self.calendarId, timeMin=period.start,
@@ -36,7 +36,7 @@ class Calendar:
     def deleteEvent(self, eventId):
         self.googleService.events().delete(calendarId=self.calendarId, eventId=eventId).execute()
 
-    def createEventFrom(self, sourceEvent, copySensibleData):
+    def createEventFrom(self, sourceEvent, copySensibleData, colorId):
         eventBody = {
             'summary': (COPIED_EVENT_LEADING_TEXT + ' ' + sourceEvent.get('summary',
                                                                           '')) if copySensibleData else COPIED_EVENT_LEADING_TEXT,
@@ -49,6 +49,8 @@ class Calendar:
             ],
             'reminders': sourceEvent.get('reminders'),
         }
+        if colorId:
+            eventBody['colorId'] = colorId
 
         createdEvent = self.googleService.events().insert(calendarId=self.calendarId, body=eventBody).execute()
 

--- a/src/calendar.py
+++ b/src/calendar.py
@@ -35,10 +35,17 @@ class Calendar:
                 self.createEventFrom(event, copySensibleData, colorId)
 
     def getEvents(self, period: DatePeriod):
-        events_result = self.googleService.events().list(calendarId=self.calendarId, timeMin=period.start,
-                                                         timeMax=period.end, singleEvents=True,
-                                                         orderBy='startTime').execute()
-        events = events_result.get('items', [])
+        events = []
+        page_token = None
+        while True:
+            events_result = self.googleService.events().list(calendarId=self.calendarId, timeMin=period.start,
+                                                             timeMax=period.end, singleEvents=True,
+                                                             orderBy='startTime', pageToken=page_token).execute(num_retries=NUM_RETRIES)
+            events.extend(events_result['items'])
+            page_token = events_result.get('nextPageToken')
+            if not page_token:
+                break
+
         return events
 
     def removeCopiedEvents(self, events):

--- a/src/calendar.py
+++ b/src/calendar.py
@@ -26,9 +26,9 @@ class Calendar:
         self.googleService = googleService
 
     def copyAllEventsFrom(self, otherCalendar, period: DatePeriod, copySensibleData, colorId, skipMatching):
-        self.removeCopiedEvents(period)
         events = otherCalendar.getEvents(period)
         existing_events = self.getEvents(period)
+        self.removeCopiedEvents(existing_events)
 
         for event in events:
             if not skipMatching or not any(start_and_end_equal(event, e) for e in existing_events):
@@ -41,9 +41,9 @@ class Calendar:
         events = events_result.get('items', [])
         return events
 
-    def removeCopiedEvents(self, period: DatePeriod):
+    def removeCopiedEvents(self, events):
         eventsToRemove = list(
-            filter(lambda event: COPIED_EVENT_LEADING_TEXT in event.get('summary', ''), self.getEvents(period)))
+            filter(lambda event: COPIED_EVENT_LEADING_TEXT in event.get('summary', ''), events))
         for event in eventsToRemove:
             self.deleteEvent(event.get("id"))
 

--- a/src/calendar.py
+++ b/src/calendar.py
@@ -11,10 +11,14 @@ SCOPES = [
 COPIED_EVENT_LEADING_TEXT = '[CLIENT MEETING]'
 
 def as_datetime(time_object):
-    return datetime.fromisoformat(time_object['dateTime'])
+    iso_value = time_object['dateTime'] if 'dateTime' in time_object else time_object['date']
+    return datetime.fromisoformat(iso_value)
 
 def start_and_end_equal(event1, event2):
-    return as_datetime(event1['start']) == as_datetime(event2['start']) and as_datetime(event1['end']) == as_datetime(event2['end'])
+    try:
+        return as_datetime(event1['start']) == as_datetime(event2['start']) and as_datetime(event1['end']) == as_datetime(event2['end'])
+    except KeyError as e:
+        raise Exception("Events lack (start,end).dateTime: %s" % {"event1": event1, "event2": event2}) from e
 
 class Calendar:
     def __init__(self, calendarId, googleService):


### PR DESCRIPTION
To be merged after #3 

This is useful if you have organizational limitations:
a) You can't use sync in both directions, thus you manually set up
"Busy" appointments in the source calendar
b) The source calendar is shared from another account with free/busy
only, thus you cannot compare by title
